### PR TITLE
String cast

### DIFF
--- a/elasticsearch-aknn/src/main/java/org/elasticsearch/plugin/aknn/AknnRestAction.java
+++ b/elasticsearch-aknn/src/main/java/org/elasticsearch/plugin/aknn/AknnRestAction.java
@@ -302,7 +302,7 @@ public class AknnRestAction extends BaseRestHandler {
             List<Double> vector = (List<Double>) source.get(VECTOR_KEY);
             source.put(HASHES_KEY, lshModel.getVectorHashes(vector));
             bulkIndexRequest.add(client
-                    .prepareIndex(index, type, (String) doc.get("_id"))
+                    .prepareIndex(index, type, doc.get("_id").toString())
                     .setSource(source));
         }
         stopWatch.stop();


### PR DESCRIPTION
Solve error: java.lang.Integer cannot be cast to java.lang.String