### PR TITLE
Filter documents for searching

### DIFF
--- a/elasticsearch-aknn/Dockerfile
+++ b/elasticsearch-aknn/Dockerfile
@@ -1,0 +1,30 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.2.4
+
+ADD . /aknn
+WORKDIR /aknn
+
+
+# Install Java 10
+# Before building this image, download the .rpm files to elasticsearch-aknn directory
+#     from http://www.oracle.com/technetwork/java/javase/downloads/index.html
+
+RUN yum -y install jdk-10.0.2_linux-x64_bin.rpm
+RUN yum -y install jre-10.0.2_linux-x64_bin.rpm
+ENV JAVA_HOME=/usr/java/jdk-10.0.2/
+
+
+# Install gradle 4.9
+
+RUN wget https://services.gradle.org/distributions/gradle-4.9-bin.zip
+RUN mkdir /opt/gradle
+RUN unzip -d /opt/gradle gradle-4.9-bin.zip
+ENV PATH=$PATH:/opt/gradle/gradle-4.9/bin
+
+
+# Build & install the plugin
+
+RUN gradle clean build -x integTestRunner -x test
+RUN elasticsearch-plugin install -b file:build/distributions/elasticsearch-aknn-0.0.1-SNAPSHOT.zip
+
+# Configure ElasticSearch
+ENV ES_JAVA_OPTS="-Xms10g -Xmx10g"

--- a/elasticsearch-aknn/Dockerfile
+++ b/elasticsearch-aknn/Dockerfile
@@ -14,8 +14,6 @@ RUN yum -y install jdk-10.0.2_linux-x64_bin.rpm
 RUN yum -y install jre-10.0.2_linux-x64_bin.rpm
 ENV JAVA_HOME=/usr/java/jdk-10.0.2/
 
-wget --no-cookies --no-check-certificate --header "Cookie: RT=sl=16&ss=1544305611360&tt=105022&obo=1&bcn=%2F%2F36fb68c2.akstat.io%2F&sh=1544307107821%3D16%3A1%3A105022%2C1544306418289%3D15%3A1%3A96370%2C1544306220860%3D14%3A1%3A89660%2C1544306204378%3D13%3A1%3A85180%2C1544306192178%3D12%3A1%3A80502&dm=oracle.com&si=2fc3a2b6-451e-42e3-a702-0d0d43f6bed0&ld=1544307107821&nu=http%3A%2F%2Fdownload.oracle.com%2Fotn%2Fjava%2Fjdk%2F10.0.2%2B13%2F19aef61b38124481863b1413dce1855f%2Fjdk-10.0.2_linux-x64_bin.rpm&cl=1544307254064;gpw_e24=https%3A%2F%2Fwww.oracle.com%2Ftechnetwork%2Fjava%2Fjavase%2Fdownloads%2Fjava-archive-javase10-4425482.html; oraclelicense=accept-securebackup-cookie" "http://download.oracle.com/otn/java/jdk/10.0.2+13/19aef61b38124481863b1413dce1855f/jdk-10.0.2_linux-x64_bin.rpm"
-
 
 # Install gradle 4.9
 

--- a/elasticsearch-aknn/Dockerfile
+++ b/elasticsearch-aknn/Dockerfile
@@ -8,9 +8,13 @@ WORKDIR /aknn
 # Before building this image, download the .rpm files to elasticsearch-aknn directory
 #     from http://www.oracle.com/technetwork/java/javase/downloads/index.html
 
+#https://www.oracle.com/technetwork/java/javase/downloads/java-archive-javase10-4425482.html
+
 RUN yum -y install jdk-10.0.2_linux-x64_bin.rpm
 RUN yum -y install jre-10.0.2_linux-x64_bin.rpm
 ENV JAVA_HOME=/usr/java/jdk-10.0.2/
+
+wget --no-cookies --no-check-certificate --header "Cookie: RT=sl=16&ss=1544305611360&tt=105022&obo=1&bcn=%2F%2F36fb68c2.akstat.io%2F&sh=1544307107821%3D16%3A1%3A105022%2C1544306418289%3D15%3A1%3A96370%2C1544306220860%3D14%3A1%3A89660%2C1544306204378%3D13%3A1%3A85180%2C1544306192178%3D12%3A1%3A80502&dm=oracle.com&si=2fc3a2b6-451e-42e3-a702-0d0d43f6bed0&ld=1544307107821&nu=http%3A%2F%2Fdownload.oracle.com%2Fotn%2Fjava%2Fjdk%2F10.0.2%2B13%2F19aef61b38124481863b1413dce1855f%2Fjdk-10.0.2_linux-x64_bin.rpm&cl=1544307254064;gpw_e24=https%3A%2F%2Fwww.oracle.com%2Ftechnetwork%2Fjava%2Fjavase%2Fdownloads%2Fjava-archive-javase10-4425482.html; oraclelicense=accept-securebackup-cookie" "http://download.oracle.com/otn/java/jdk/10.0.2+13/19aef61b38124481863b1413dce1855f/jdk-10.0.2_linux-x64_bin.rpm"
 
 
 # Install gradle 4.9

--- a/elasticsearch-aknn/Dockerfile
+++ b/elasticsearch-aknn/Dockerfile
@@ -13,6 +13,8 @@ WORKDIR /aknn
 RUN yum -y install jdk-10.0.2_linux-x64_bin.rpm
 RUN yum -y install jre-10.0.2_linux-x64_bin.rpm
 ENV JAVA_HOME=/usr/java/jdk-10.0.2/
+RUN rm jdk-10.0.2_linux-x64_bin.rpm
+RUN rm jre-10.0.2_linux-x64_bin.rpm
 
 
 # Install gradle 4.9

--- a/elasticsearch-aknn/docker-compose.yml
+++ b/elasticsearch-aknn/docker-compose.yml
@@ -1,0 +1,44 @@
+version: '3'
+services:
+  elasticsearch:
+    image: jainaayush05/es-aknn:latest
+    container_name: elasticsearch
+    environment:
+      - cluster.name=docker-cluster
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - esdata1:/usr/share/elasticsearch/data
+    ports:
+      - 9200:9200
+    networks:
+      - esnet
+  elasticsearch2:
+    image: jainaayush05/es-aknn:latest
+    container_name: elasticsearch2
+    environment:
+      - cluster.name=docker-cluster
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "discovery.zen.ping.unicast.hosts=elasticsearch"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - esdata2:/usr/share/elasticsearch/data
+    networks:
+      - esnet
+
+volumes:
+  esdata1:
+    driver: local
+  esdata2:
+    driver: local
+
+networks:
+  esnet:

--- a/elasticsearch-aknn/src/main/java/org/elasticsearch/plugin/aknn/AknnRestAction.java
+++ b/elasticsearch-aknn/src/main/java/org/elasticsearch/plugin/aknn/AknnRestAction.java
@@ -98,16 +98,16 @@ public class AknnRestAction extends BaseRestHandler {
     }
 
     public static Double cosineDistance(List<Double> A, List<Double> B) {
-        Double dotProduct = 0.0;
-        Double magnitude1 = 0.0;
-        Double magnitude2 = 0.0;
-        Double cosineSimilarity = 0.0;
+        Double dotProduct = 0.;
+        Double magnitude1 = 0.;
+        Double magnitude2 = 0.;
+        Double cosineSimilarity = 0.;
 
-        for (Integer i = 0; i < A.size(); i++)
+        for (Integer i = 0; i < A.size(); i++){
             dotProduct += A.get(i) * B.get(i);  //a.b
             magnitude1 += Math.pow(A.get(i), 2);  //(a^2)
             magnitude2 += Math.pow(B.get(i), 2); //(b^2)
-
+        }
 
         magnitude1 = Math.sqrt(magnitude1);//sqrt(a^2)
         magnitude2 = Math.sqrt(magnitude2);//sqrt(b^2)

--- a/elasticsearch-aknn/src/main/java/org/elasticsearch/plugin/aknn/AknnRestAction.java
+++ b/elasticsearch-aknn/src/main/java/org/elasticsearch/plugin/aknn/AknnRestAction.java
@@ -108,7 +108,7 @@ public class AknnRestAction extends BaseRestHandler {
         final String id = restRequest.param("id");
         final Integer k1 = restRequest.paramAsInt("k1", K1_DEFAULT);
         final Integer k2 = restRequest.paramAsInt("k2", K2_DEFAULT);
-        final String filter = restRequest.param("filter", FILTER_DEFAULT);
+        final String f = restRequest.param("filter", FILTER_DEFAULT);
         stopWatch.stop();
 
         logger.info("Get query document at {}/{}/{}", index, type, id);
@@ -135,7 +135,7 @@ public class AknnRestAction extends BaseRestHandler {
         QueryBuilder queryBuilder = QueryBuilders.boolQuery();
         for (Map.Entry<String, Long> entry : queryHashes.entrySet()) {
             String termKey = HASHES_KEY + "." + entry.getKey();
-            ((BoolQueryBuilder) queryBuilder).filter(new WrapperQueryBuilder(filter)).should(QueryBuilders.termQuery(termKey, entry.getValue()));
+            ((BoolQueryBuilder) queryBuilder).filter(new WrapperQueryBuilder(f)).should(QueryBuilders.termQuery(termKey, entry.getValue()));
         }
         stopWatch.stop();
 

--- a/elasticsearch-aknn/src/main/java/org/elasticsearch/plugin/aknn/AknnRestAction.java
+++ b/elasticsearch-aknn/src/main/java/org/elasticsearch/plugin/aknn/AknnRestAction.java
@@ -97,6 +97,30 @@ public class AknnRestAction extends BaseRestHandler {
         return Math.sqrt(squaredDistance);
     }
 
+    public static Double cosineDistance(List<Double> A, List<Double> B) {
+        Double dotProduct = 0.0;
+        Double magnitude1 = 0.0;
+        Double magnitude2 = 0.0;
+        Double cosineSimilarity = 0.0;
+
+        for (Integer i = 0; i < A.size(); i++)
+            dotProduct += A.get(i) * B.get(i);  //a.b
+            magnitude1 += Math.pow(A.get(i), 2);  //(a^2)
+            magnitude2 += Math.pow(B.get(i), 2); //(b^2)
+
+
+        magnitude1 = Math.sqrt(magnitude1);//sqrt(a^2)
+        magnitude2 = Math.sqrt(magnitude2);//sqrt(b^2)
+
+        if (magnitude1 != 0.0 | magnitude2 != 0.0) {
+            cosineSimilarity = dotProduct / (magnitude1 * magnitude2);
+        } else {
+            return 0.0;
+        }
+        return cosineSimilarity;
+
+    }
+
     private RestChannelConsumer handleSearchRequest(RestRequest restRequest, NodeClient client) throws IOException {
 
         StopWatch stopWatch = new StopWatch("StopWatch to Time Search Request");
@@ -165,7 +189,7 @@ public class AknnRestAction extends BaseRestHandler {
                 put("_index", hit.getIndex());
                 put("_id", hit.getId());
                 put("_type", hit.getType());
-                put("_score", euclideanDistance(queryVector, hitVector));
+                put("_score", cosineDistance(queryVector, hitVector));
                 put("_source", hitSource);
             }});
         }


### PR DESCRIPTION
One of the biggest drawbacks of libs like annoy or Faiss is that it doesn't allow filtering of documents to be searched before finding nearest neighbours. This is something that can be solved using the changes I have suggested